### PR TITLE
Support reading gzipped layers and non-tar files when extract a Docker image to Noseyparker

### DIFF
--- a/pkg/types/docker.go
+++ b/pkg/types/docker.go
@@ -236,15 +236,15 @@ func (i *DockerImage) getLayerReader(tarReader *tar.Reader, layerName string) (*
 	return tar.NewReader(layerReader), cleanup, nil
 }
 
-func (i *DockerImage) processFile(tarReader *tar.Reader, layerName string, manifest []DockerManifest) ([]NPInput, error) {
+func (i *DockerImage) processFile(tarReader *tar.Reader, fileName string, manifest []DockerManifest) ([]NPInput, error) {
 	content, err := io.ReadAll(tarReader)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed reading file %s: %w", layerName, err)
+		return nil, fmt.Errorf("failed reading file %s: %w", fileName, err)
 	}
 
 	if len(content) == 0 {
-		return nil, fmt.Errorf("file %q is empty", layerName)
+		return nil, fmt.Errorf("file %q is empty", fileName)
 	}
 
 	input := NPInput{
@@ -253,7 +253,7 @@ func (i *DockerImage) processFile(tarReader *tar.Reader, layerName string, manif
 			Platform:     "docker",
 			ResourceType: "image",
 			ResourceID:   manifest[0].RepoTags[0],
-			Region:       fmt.Sprintf("file:%s", layerName),
+			Region:       fmt.Sprintf("file:%s", fileName),
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for reading and processing gzipped Docker layers, which is how most image layers are saved as now. The image config is now also read which stores the image's env variables (which could contain secrets). The change in `processFile` was needed as otherwise all reading of regular files fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatic handling of gzip-compressed Docker image layers.

* **Bug Fixes**
  * Improved identification of non-layer files in Docker image manifests.

* **Other Improvements**
  * Clarified file naming in processing and error messages for better transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->